### PR TITLE
Added FEATURE_STRICT_APDU_CHAINING to support cancelling mid-command

### DIFF
--- a/src/com/makina/security/OpenFIPS201/Config.java
+++ b/src/com/makina/security/OpenFIPS201/Config.java
@@ -127,7 +127,13 @@ public abstract class Config {
     /// SP800-73-4 Requirement: Not specified under PIV (extension functionality)
     public static final boolean FEATURE_DISCOVERY_OBJECT_DEFAULT = true;
 
-
+	// If set to true, the applet will return SW_LAST_COMMAND_EXPECTED if a chained APDU is
+	// not completed. The implication of this is that if a chained INCOMING or OUTGOING
+	// APDU is cancelled by the host by starting a new APDU, an error will be produced.
+	//
+    /// SP800-73-4 Requirement: Not specified under PIV (extension functionality)
+    public static final boolean FEATURE_STRICT_APDU_CHAINING = false;
+    
     ///////////////////////////////////////////////////////////////////////////
     //
     // PIN and PUK CONFIGURATION

--- a/src/com/makina/security/OpenFIPS201/PIV.java
+++ b/src/com/makina/security/OpenFIPS201/PIV.java
@@ -941,8 +941,8 @@ public final class PIV {
         // COMMAND CHAIN HANDLING
         //
 
-        // Pass the APDU to the chainBuffer instance first. It will return zero if there is store more
-        // to of the chain to process, otherwise it will return the length of the large CDATA buffer
+        // Pass the APDU to the chainBuffer instance first. It will return zero if there is more
+        // of the chain to process, otherwise it will return the length of the large CDATA buffer
         length = chainBuffer.processIncomingAPDU(buffer, offset, length, scratch, (short)0);
 
         // If the length is zero, just return so the caller can keep sending
@@ -1750,7 +1750,6 @@ public final class PIV {
 
         // If we got this far, the scratch buffer now contains the incoming DATA. Keep in mind that the original buffer
         // still contains the APDU header.
-
 
         //
         // PIN cases


### PR DESCRIPTION
This resolves #4. 
For data objects or outgoing data (R-APDU), it automatically cancels the transaction and continues on to allow the applet to process the new command.
For incoming APDU's, since this is processed inside each individual INS handler there is now an additional check performed (checkIncomingAPDU()) before normal handling to account for changed commands.