### PR TITLE
Don't clear the public key from PIVKeyObject after key generation

### DIFF
--- a/src/com/makina/security/OpenFIPS201/PIVKeyObjectPKI.java
+++ b/src/com/makina/security/OpenFIPS201/PIVKeyObjectPKI.java
@@ -100,8 +100,6 @@ public abstract class PIVKeyObjectPKI extends PIVKeyObject {
       // We effectively new'd these objects so we will make sure the memory
       // is freed up.
       keyPair = null;
-      // Any existing public key is now invalid
-      clearPublic();
       runGc();
     }
     return length;


### PR DESCRIPTION
Proposed fix for issue #34 