### PR TITLE
Fixes #55

### DIFF
--- a/src/com/makina/security/openfips201/ChainBuffer.java
+++ b/src/com/makina/security/openfips201/ChainBuffer.java
@@ -220,7 +220,6 @@ final class ChainBuffer {
       // We have been called in the middle of another operation! call resetAbort in case there is
       // some outstanding transaction
       resetAbort();
-      ISOException.throwIt(ISO7816.SW_CONDITIONS_NOT_SATISFIED);
     }
 
     //


### PR DESCRIPTION
As discussed in #63 and #55, ISO7816-4 allows skipping unnecessary data, so it is not necessary to deny further operations when this happens.