### PR TITLE
nullify publicKey on PIVKeyObjectRSA::clear

### DIFF
--- a/src/com/makina/security/openfips201/PIVKeyObjectRSA.java
+++ b/src/com/makina/security/openfips201/PIVKeyObjectRSA.java
@@ -148,7 +148,7 @@ final class PIVKeyObjectRSA extends PIVKeyObjectPKI {
   void clear() {
     if (publicKey != null) {
       publicKey.clearKey();
-      privateKey = null;
+      publicKey = null;
     }
     if (privateKey != null) {
       privateKey.clearKey();


### PR DESCRIPTION
clear does not nullify the publicKey, probably due to a typo