### PR TITLE
OF201V2 Bugfixes

### DIFF
--- a/src/org/openfips201/applet/PIV.java
+++ b/src/org/openfips201/applet/PIV.java
@@ -264,7 +264,7 @@ final class PIV {
       // Special - Handle the 2-byte BITG case
       case Constants.ID_DATA_BITG:
         buffer[0] = Constants.ID_DATA_BITG_MSB;
-        buffer[1] = Constants.ID_DATA_BITG_MSB;
+        buffer[1] = Constants.ID_DATA_BITG_LSB;
         buffer[2] = 0;
         length = 3;
         break;

--- a/src/org/openfips201/applet/PIVAPDU.java
+++ b/src/org/openfips201/applet/PIVAPDU.java
@@ -773,7 +773,12 @@ final class PIVAPDU {
         apdu.setOutgoingLength(outLength);
         apdu.sendBytes(Constants.ZERO_SHORT, outLength);
       } else {
-        // Same as plaintext
+        short remaining = (short)(context[CONTEXT_REMAINING] - inLength);
+        if (remaining > 0) {
+          status = ISO7816.SW_BYTES_REMAINING_00;
+          status |= (remaining > (short)0xff) ? (short)0xff : remaining;
+        }
+
         apdu.setOutgoingLength(outLength);
         if (outLength > 0) {
           apdu.sendBytesLong(data, context[CONTEXT_OFFSET], outLength);


### PR DESCRIPTION
Hey there. Sorry for the lack of activity, life got in the way. During some testing, I identified two bugs which are resolved with this PR:

1. GET DATA for the BITG object returned in it's response the BITG_MSB twice, instead of BITG_MSB||BITG_LSB
2. When issuing commands that would require response chaining whilst being authenticated with the minimal admin SCP channel (C-DEC+C-MAC per OF201V1 convention), response chaining is not performed due to isResponseWrapped() checking only for R-ENC or R-MAC flags, truncating, f. i. a public key returned by GENERATE ASYMMETRIC KEYPAIR

This PR fixes these two minor bugs.